### PR TITLE
Disable Render Target cameras (for now)

### DIFF
--- a/moon/wiremod_limits/init.moon
+++ b/moon/wiremod_limits/init.moon
@@ -4,6 +4,7 @@ export CFCWiremodLimits = {
 
 include "lib/throttle.lua"
 include "lib/e2.lua"
+include "lib/rt.lua"
 
 hook.Add "InitPostEntity", "CFC_WiremodLimits_LoadModules", ->
     include "wiremod_limits/modules/e2.lua"

--- a/moon/wiremod_limits/modules/rt.moon
+++ b/moon/wiremod_limits/modules/rt.moon
@@ -1,0 +1,5 @@
+hook.Add "InitPostEntity", "CFC_WiremodLimitations_DisableRT", ->
+    return unless WireLib
+
+    hook.Remove "PreRender", "ImprovedRTCamera"
+    scripted_ents.GetStored("gmod_wire_rt_camera").t.InitRTTexture = ->


### PR DESCRIPTION
I have a way to properly limit these in a way that isn't shit or simple rank restrictions, but it needs some time.

Until then, I don't want to stop people's dupes from spawning because of spawn limits or restrictions, so I'm just disabling the actual bad parts.